### PR TITLE
Add 'sslverify' option to config file to disable SSL cert verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,17 @@ Configuration
 Options can be set in a configuration file, as environment variables or on the command line.
 Profiles can be used to easily switch between different configuration settings.
 
-    | Option   | Config File | Environment Variable       | Optional Argument               | Default                   |
-    |----------|-------------|----------------------------|---------------------------------|---------------------------|
-    | file     | n/a         | ``ALERTA_CONF_FILE``       | n/a                             | ``~/.alerta.conf``        |
-    | profile  | profile     | ``ALERTA_DEFAULT_PROFILE`` | ``--profile PROFILE``           | None                      |
-    | endpoint | endpoint    | ``ALERTA_ENDPOINT``        | ``--endpoint-url URL``          | ``http://localhost:8080`` |
-    | key      | key         | ``ALERTA_API_KEY``         | n/a                             | None                      |
-    | timezone | timezone    | n/a                        | n/a                             | Europe/London             |
-    | output   | output      | n/a                        | ``--output OUTPUT``, ``--json`` | text                      |
-    | color    | color       | ``CLICOLOR``               | ``--color``, ``--no-color``     | color on                  |
-    | debug    | debug       | ``DEBUG``                  | ``--debug``                     | no debug                  |
+| Option     | Config File | Environment Variable       | Optional Argument               | Default                   |
+|------------|-------------|----------------------------|---------------------------------|---------------------------|
+| file       | n/a         | ``ALERTA_CONF_FILE``       | n/a                             | ``~/.alerta.conf``        |
+| profile    | profile     | ``ALERTA_DEFAULT_PROFILE`` | ``--profile PROFILE``           | None                      |
+| endpoint   | endpoint    | ``ALERTA_ENDPOINT``        | ``--endpoint-url URL``          | ``http://localhost:8080`` |
+| key        | key         | ``ALERTA_API_KEY``         | n/a                             | None                      |
+| timezone   | timezone    | n/a                        | n/a                             | Europe/London             |
+| SSL verify | sslverify   | ``REQUESTS_CA_BUNDLE``     | n/a                             | verify SSL certificates   |
+| output     | output      | n/a                        | ``--output OUTPUT``, ``--json`` | text                      |
+| color      | color       | ``CLICOLOR``               | ``--color``, ``--no-color``     | color on                  |
+| debug      | debug       | ``DEBUG``                  | ``--debug``                     | no debug                  |
 
 Example
 -------
@@ -50,7 +51,8 @@ Configuration file ``~/.alerta.conf``::
     key = demo-key
 
     [profile development]
-    endpoint = http://localhost:8080
+    endpoint = https://localhost:8443
+    sslverify = off
     debug = yes
 
 Environment Variables

--- a/alertaclient/api.py
+++ b/alertaclient/api.py
@@ -30,10 +30,11 @@ class ApiAuth(AuthBase):
 
 class ApiClient(object):
 
-    def __init__(self, endpoint=None, key=None):
+    def __init__(self, endpoint=None, key=None, ssl_verify=True):
 
         self.endpoint = endpoint or os.environ.get('ALERTA_ENDPOINT', "http://localhost:8080")
         self.key = key or os.environ.get('ALERTA_API_KEY', '')
+        self.ssl_verify = ssl_verify  # or REQUESTS_CA_BUNDLE env var
         self.session = requests.Session()
 
     def __repr__(self):
@@ -174,7 +175,7 @@ class ApiClient(object):
         query = query or tuple()
 
         url = self.endpoint + path + '?' + urlencode(query, doseq=True)
-        response = self.session.get(url, auth=ApiAuth(self.key))
+        response = self.session.get(url, auth=ApiAuth(self.key), verify=self.ssl_verify)
 
         LOG.debug('Request Headers: %s', response.request.headers)
 
@@ -193,7 +194,7 @@ class ApiClient(object):
         url = self.endpoint + path
         headers = {'Content-Type': 'application/json'}
 
-        response = self.session.post(url, data=data, auth=ApiAuth(self.key), headers=headers)
+        response = self.session.post(url, data=data, headers=headers, auth=ApiAuth(self.key), verify=self.ssl_verify)
 
         LOG.debug('Request Headers: %s', response.request.headers)
         LOG.debug('Request Body: %s', data)
@@ -208,7 +209,7 @@ class ApiClient(object):
         url = self.endpoint + path
         headers = {'Content-Type': 'application/json'}
 
-        response = self.session.put(url, data=data, auth=ApiAuth(self.key), headers=headers)
+        response = self.session.put(url, data=data, headers=headers, auth=ApiAuth(self.key), verify=self.ssl_verify)
 
         LOG.debug('Request Headers: %s', response.request.headers)
         LOG.debug('Request Body: %s', data)
@@ -221,7 +222,7 @@ class ApiClient(object):
     def _delete(self, path):
 
         url = self.endpoint + path
-        response = self.session.delete(url, auth=ApiAuth(self.key))
+        response = self.session.delete(url, auth=ApiAuth(self.key), verify=self.ssl_verify)
 
         LOG.debug('Request Headers: %s', response.request.headers)
 


### PR DESCRIPTION
Fixes #45, for example ...
```sh
$ alerta --endpoint https://api.alerta.io query
2016-09-30 23:35:55,609 - requests.packages.urllib3.connection - ERROR - Certificate did not match expected hostname: api.alerta.io. Certificate: {'crlDistributionPoints': (u'http://crl3.digicert.com/sha2-ha-server-g3.crl', u'http://crl4.digicert.com/sha2-ha-server-g3.crl'), 'subjectAltName': (('DNS', '*.rhcloud.com'), ('DNS', 'rhcloud.com')), 'notBefore': u'Apr  7 00:00:00 2015 GMT', 'caIssuers': (u'http://cacerts.digicert.com/DigiCertSHA2HighAssuranceServerCA.crt',), 'OCSP': (u'http://ocsp.digicert.com',), 'serialNumber': u'0AAEF3ADAEA9C84B25C9D7FA9E37232E', 'notAfter': 'Apr 11 12:00:00 2018 GMT', 'version': 3L, 'subject': ((('countryName', u'US'),), (('stateOrProvinceName', u'North Carolina'),), (('localityName', u'Raleigh'),), (('organizationName', u'Red Hat Inc.'),), (('commonName', u'*.rhcloud.com'),)), 'issuer': ((('countryName', u'US'),), (('organizationName', u'DigiCert Inc'),), (('organizationalUnitName', u'www.digicert.com'),), (('commonName', u'DigiCert SHA2 High Assurance Server CA'),))}
2016-09-30 23:35:55,613 - alertaclient.shell - ERROR - hostname 'api.alerta.io' doesn't match either of '*.rhcloud.com', 'rhcloud.com'
```

Add the following to `alerta` command line configuration file eg. `~/.alerta.conf`: 
```
[DEFAULT]
sslverify = off
```

Or specify for an individual profile:
```
[profile openshift]
endpoint = https://api.alerta.io
key = demo-key
sslverify = off
```
See http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification