### PR TITLE
Convert timedelta to string for formatting

### DIFF
--- a/alertaclient/shell.py
+++ b/alertaclient/shell.py
@@ -503,7 +503,7 @@ class AlertCommand(object):
                 hb.get_date('create_time', 'local', args.timezone),
                 latency,
                 hb.timeout,
-                since,
+                str(since),
                 status()
             ))
 


### PR DESCRIPTION
Fixes guardian/alerta#331 (Note: This only effected python3 environments)