### PR TITLE
Allow text arg for status changes

### DIFF
--- a/alertaclient/api.py
+++ b/alertaclient/api.py
@@ -83,23 +83,23 @@ class ApiClient(object):
 
         return self._put('/alert/%s/untag' % alertid, data=json.dumps({"tags": tags}))
 
-    def open_alert(self, alertid, text):
+    def open_alert(self, alertid, text=''):
 
         self.update_status(alertid, 'open', text)
 
-    def ack_alert(self, alertid, text=None):
+    def ack_alert(self, alertid, text=''):
 
         self.update_status(alertid, 'ack', text)
 
-    def unack_alert(self, alertid, text=None):
+    def unack_alert(self, alertid, text=''):
 
         self.open_alert(alertid, text)
 
-    def assign_alert(self, alertid, text=None):
+    def assign_alert(self, alertid, text=''):
 
         self.update_status(alertid, 'assigned', text)
 
-    def close_alert(self, alertid, text=None):
+    def close_alert(self, alertid, text=''):
 
         self.update_status(alertid, 'closed', text)
 

--- a/alertaclient/api.py
+++ b/alertaclient/api.py
@@ -83,29 +83,29 @@ class ApiClient(object):
 
         return self._put('/alert/%s/untag' % alertid, data=json.dumps({"tags": tags}))
 
-    def open_alert(self, alertid):
+    def open_alert(self, alertid, text):
 
-        self.update_status(alertid, 'open')
+        self.update_status(alertid, 'open', text)
 
-    def ack_alert(self, alertid):
+    def ack_alert(self, alertid, text=None):
 
-        self.update_status(alertid, 'ack')
+        self.update_status(alertid, 'ack', text)
 
-    def unack_alert(self, alertid):
+    def unack_alert(self, alertid, text=None):
 
-        self.open_alert(alertid)
+        self.open_alert(alertid, text)
 
-    def assign_alert(self, alertid):
+    def assign_alert(self, alertid, text=None):
 
-        self.update_status(alertid, 'assigned')
+        self.update_status(alertid, 'assigned', text)
 
-    def close_alert(self, alertid):
+    def close_alert(self, alertid, text=None):
 
-        self.update_status(alertid, 'closed')
+        self.update_status(alertid, 'closed', text)
 
-    def update_status(self, alertid, status):
+    def update_status(self, alertid, status, text):
 
-        return self._put('/alert/%s/status' % alertid, data=json.dumps({"status": status}))
+        return self._put('/alert/%s/status' % alertid, data=json.dumps({"status": status, "text": text}))
 
     def delete_alert(self, alertid):
 

--- a/alertaclient/shell.py
+++ b/alertaclient/shell.py
@@ -1124,6 +1124,7 @@ class AlertaShell(object):
         parser_ack.add_argument(
             '-t',
             '--text',
+            default='',
             help='text'
         )
         parser_ack.set_defaults(func=cli.ack)
@@ -1149,6 +1150,7 @@ class AlertaShell(object):
         parser_unack.add_argument(
             '-t',
             '--text',
+            default='',
             help='text'
         )
         parser_unack.set_defaults(func=cli.unack)
@@ -1175,6 +1177,7 @@ class AlertaShell(object):
         parser_close.add_argument(
             '-t',
             '--text',
+            default='',
             help='text'
         )
         parser_close.set_defaults(func=cli.close)

--- a/alertaclient/shell.py
+++ b/alertaclient/shell.py
@@ -329,7 +329,7 @@ class AlertCommand(object):
             sys.stdout.write("%3d%% (%d/%d)" % (pct, i, total))
             sys.stdout.flush()
             sys.stdout.write("\b" * (8 + len(str(i)) + len(str(total))))
-            self.api.ack_alert(alert['id'])
+            self.api.ack_alert(alert['id'], text=args.text)
 
         sys.stdout.write("100%% (%d/%d), done.\n" % (total, total))
 
@@ -348,7 +348,7 @@ class AlertCommand(object):
             sys.stdout.write("%3d%% (%d/%d)" % (pct, i, total))
             sys.stdout.flush()
             sys.stdout.write("\b" * (8 + len(str(i)) + len(str(total))))
-            self.api.unack_alert(alert['id'])
+            self.api.unack_alert(alert['id'], text=args.text)
 
         sys.stdout.write("100%% (%d/%d), done.\n" % (total, total))
 
@@ -367,7 +367,7 @@ class AlertCommand(object):
             sys.stdout.write("%3d%% (%d/%d)" % (pct, i, total))
             sys.stdout.flush()
             sys.stdout.write("\b" * (8 + len(str(i)) + len(str(total))))
-            self.api.close_alert(alert['id'])
+            self.api.close_alert(alert['id'], text=args.text)
 
         sys.stdout.write("100%% (%d/%d), done.\n" % (total, total))
 
@@ -1121,6 +1121,11 @@ class AlertaShell(object):
             default=list(),
             help='KEY=VALUE eg. serverity=warning resource=web'
         )
+        parser_ack.add_argument(
+            '-t',
+            '--text',
+            help='text'
+        )
         parser_ack.set_defaults(func=cli.ack)
 
         parser_unack = subparsers.add_parser(
@@ -1140,6 +1145,11 @@ class AlertaShell(object):
             nargs='+',
             default=list(),
             help='KEY=VALUE eg. serverity=warning resource=web'
+        )
+        parser_unack.add_argument(
+            '-t',
+            '--text',
+            help='text'
         )
         parser_unack.set_defaults(func=cli.unack)
 
@@ -1161,6 +1171,11 @@ class AlertaShell(object):
             nargs='+',
             default=list(),
             help='KEY=VALUE eg. serverity=warning resource=web'
+        )
+        parser_close.add_argument(
+            '-t',
+            '--text',
+            help='text'
         )
         parser_close.set_defaults(func=cli.close)
 


### PR DESCRIPTION
**Example**
```
$ alerta ack -h
usage: alerta [OPTIONS] ack [--ids IDs] [--filters FILTERS]

optional arguments:
  -h, --help            show this help message and exit
  -i IDs [IDs ...], --ids IDs [IDs ...]
                        List of alert IDs (can use short 8-char id).
  --filters FILTERS [FILTERS ...]
                        KEY=VALUE eg. serverity=warning resource=web
  -t TEXT, --text TEXT  text
```