### PR TITLE
Alert on stale or slow heartbeats

### DIFF
--- a/alertaclient/commands/cmd_heartbeats.py
+++ b/alertaclient/commands/cmd_heartbeats.py
@@ -2,12 +2,15 @@
 import click
 
 from tabulate import tabulate
+from alertaclient.models.heartbeat import MAX_LATENCY
 
 
 @click.command('heartbeats', short_help='List heartbeats')
+@click.option('--alert', is_flag=True, help='Send alerts on stale or slow heartbeats')
+@click.option('--severity', '-s', metavar='SEVERITY', default='major', help='Set the severity for stale heartbeat alerts')
 @click.option('--purge', is_flag=True, help='Delete stale heartbeats')
 @click.pass_obj
-def cli(obj, purge):
+def cli(obj, alert, severity, purge):
     """List heartbeats."""
     client = obj['client']
     timezone = obj['timezone']
@@ -18,8 +21,59 @@ def cli(obj, purge):
     heartbeats = client.get_heartbeats()
     click.echo(tabulate([h.tabular(timezone) for h in heartbeats], headers=headers, tablefmt=obj['output']))
 
-    expired = [hb for hb in heartbeats if hb.status == 'expired']
+    not_ok = [hb for hb in heartbeats if hb.status != 'ok']
     if purge:
-        with click.progressbar(expired, label='Purging {} heartbeats'.format(len(expired))) as bar:
+        with click.progressbar(not_ok, label='Purging {} heartbeats'.format(len(not_ok))) as bar:
             for b in bar:
                 client.delete_heartbeat(b.id)
+
+    elif alert:
+        with click.progressbar(heartbeats, label='Alerting {} heartbeats'.format(len(heartbeats))) as bar:
+            for b in bar:
+                params = dict(filter(lambda a: len(a) == 2, map(lambda a: a.split(':'), b.tags)))
+                environment = params.get('environment', 'Production')
+                group = params.get('group', 'System')
+                tags = list(filter(lambda a: not a.startswith('environment:') and not a.startswith('group:'), b.tags))
+
+                if b.status == 'expired':  # aka. "stale"
+                    client.send_alert(
+                        resource=b.origin,
+                        event='HeartbeatFail',
+                        correlate=['HeartbeatFail', 'HeartbeatSlow', 'HeartbeatOK'],
+                        group=group,
+                        environment=environment,
+                        service=['Alerta'],
+                        severity=severity,
+                        value='{}'.format(b.since),
+                        text='Heartbeat not received in {} seconds'.format(b.timeout),
+                        tags=tags,
+                        type='heartbeatAlert'
+                    )
+                elif b.status == 'slow':
+                    client.send_alert(
+                        resource=b.origin,
+                        event='HeartbeatSlow',
+                        correlate=['HeartbeatFail', 'HeartbeatSlow', 'HeartbeatOK'],
+                        group=group,
+                        environment=environment,
+                        service=['Alerta'],
+                        severity=severity,
+                        value='{}ms'.format(b.latency),
+                        text='Heartbeat took more than {}ms to be processed'.format(MAX_LATENCY),
+                        tags=tags,
+                        type='heartbeatAlert'
+                    )
+                else:
+                    client.send_alert(
+                        resource=b.origin,
+                        event='HeartbeatOK',
+                        correlate=['HeartbeatFail', 'HeartbeatSlow', 'HeartbeatOK'],
+                        group=group,
+                        environment=environment,
+                        service=['Alerta'],
+                        severity='normal',
+                        value='',
+                        text='Heartbeat OK',
+                        tags=tags,
+                        type='heartbeatAlert'
+                    )


### PR DESCRIPTION
**Usage**
```$ alerta --profile heroku heartbeats --help
Usage: alerta heartbeats [OPTIONS]

  List heartbeats.

Options:
  --alert                  Send alerts on stale or slow heartbeats
  -s, --severity SEVERITY  Set the severity for stale heartbeat alerts
  --purge                  Delete stale heartbeats
  --help                   Show this message and exit.
```
**Example**
```
$ alerta --profile heroku heartbeats --alert --severity minor
 ID                                   | ORIGIN                        | CUSTOMER       | TAGS   | CREATED             | RECEIVED            | LATENCY   | TIMEOUT   | SINCE              | STATUS
--------------------------------------+-------------------------------+----------------+--------+---------------------+---------------------+-----------+-----------+--------------------+----------
 bd63643b-aa4c-46c4-84d2-6d1c51ba0582 | alerta-syslog/macbookpro.home |                | 3.4.3  | 2016/09/29 20:54:01 | 2016/09/29 20:54:01 | 41ms      | 300s      | 382 days, 3:11:08  | slow
 370a5f92-6b0d-4fa9-937f-45f8748f507d | alerta/c9b52479.local         |                |        | 2016/11/17 10:46:52 | 2016/11/17 10:46:52 | 134ms     | 300s      | 333 days, 12:18:16 | slow
 e5d726e6-f174-4528-9e6e-7c9859b347f6 | alerta/fdaa33ca.home          |                |        | 2017/10/17 00:04:21 | 2017/10/17 00:04:21 | 0ms       | 86400s    | 0:00:48            | ok
 3b64e9f4-e4ab-4bee-b852-0d318ea35dff | alerta/fdaa33ca.local         | Tyrell Corp. ‡ |        | 2017/07/06 10:07:21 | 2017/07/06 10:07:21 | 126ms     | 300s      | 102 days, 13:57:48 | slow
Escalating 3 heartbeats  [####################################]  100%
```
