### PR TITLE
Fix query command output options

### DIFF
--- a/alertaclient/cli.py
+++ b/alertaclient/cli.py
@@ -11,8 +11,7 @@ CONTEXT_SETTINGS = dict(
     auto_envvar_prefix='ALERTA',
     default_map={'query': {'compact': True}}
 )
-cmd_folder = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                          'commands'))
+cmd_folder = os.path.abspath(os.path.join(os.path.dirname(__file__), 'commands'))
 
 
 class AlertaCLI(click.MultiCommand):
@@ -30,8 +29,7 @@ class AlertaCLI(click.MultiCommand):
         try:
             if sys.version_info[0] == 2:
                 name = name.encode('ascii', 'replace')
-            mod = __import__('alertaclient.commands.cmd_' + name,
-                             None, None, ['cli'])
+            mod = __import__('alertaclient.commands.cmd_' + name, None, None, ['cli'])
         except ImportError:
             return
         return mod.cli


### PR DESCRIPTION
```
$ alerta query --help
Usage: alerta query [OPTIONS]

  Query for alerts based on search filter criteria.

Options:
  -i, --ids UUID       List of alert IDs (can use short 8-char id)
  -f, --filter FILTER  KEY=VALUE eg. serverity=warning resource=web
  --tabular            Tabular output
  --compact            Compact output
  --details            Compact output with details
  --help               Show this message and exit.
```