### PR TITLE
Add support for JSON output format

### DIFF
--- a/alertaclient/cli.py
+++ b/alertaclient/cli.py
@@ -40,6 +40,7 @@ class AlertaCLI(click.MultiCommand):
 @click.option('--profile', metavar='<PROFILE>', help='Configuration profile.')
 @click.option('--endpoint-url', metavar='<URL>', help='API endpoint URL.')
 @click.option('--output', 'output', metavar='<FORMAT>', help='Output format. eg. simple, grid, psql, presto, rst')
+@click.option('--json', 'output', flag_value='json', help='Output in JSON format. Shortcut for "--output json"')
 @click.option('--color/--no-color', help='Color-coded output based on severity.')
 @click.option('--debug', is_flag=True, help='Debug mode.')
 @click.pass_context

--- a/alertaclient/commands/cmd_blackouts.py
+++ b/alertaclient/commands/cmd_blackouts.py
@@ -1,6 +1,7 @@
 
-
+import sys
 import click
+import json
 
 from tabulate import tabulate
 
@@ -11,6 +12,12 @@ from tabulate import tabulate
 def cli(obj, purge):
     """List alert suppressions."""
     client = obj['client']
+
+    if obj['output'] == 'json':
+        r = client.http.get('/blackouts')
+        click.echo(json.dumps(r['blackouts'], sort_keys=True, indent=4, ensure_ascii=False))
+        sys.exit(0)
+
     timezone = obj['timezone']
     headers = {
         'id': 'ID', 'priority': 'P', 'environment': 'ENVIRONMENT', 'service': 'SERVICE', 'resource': 'RESOURCE',

--- a/alertaclient/commands/cmd_customers.py
+++ b/alertaclient/commands/cmd_customers.py
@@ -1,6 +1,7 @@
 
-
+import sys
 import click
+import json
 
 from tabulate import tabulate
 
@@ -10,5 +11,11 @@ from tabulate import tabulate
 def cli(obj):
     """List customer lookups."""
     client = obj['client']
+
+    if obj['output'] == 'json':
+        r = client.http.get('/customers')
+        click.echo(json.dumps(r['customers'], sort_keys=True, indent=4, ensure_ascii=False))
+        sys.exit(0)
+
     headers = {'id': 'ID', 'customer': 'CUSTOMER', 'match': 'GROUP'}
     click.echo(tabulate([c.tabular() for c in client.get_customers()], headers=headers, tablefmt=obj['output']))

--- a/alertaclient/commands/cmd_heartbeats.py
+++ b/alertaclient/commands/cmd_heartbeats.py
@@ -1,5 +1,7 @@
 
+import sys
 import click
+import json
 
 from tabulate import tabulate
 from alertaclient.models.heartbeat import MAX_LATENCY
@@ -13,6 +15,12 @@ from alertaclient.models.heartbeat import MAX_LATENCY
 def cli(obj, alert, severity, purge):
     """List heartbeats."""
     client = obj['client']
+
+    if obj['output'] == 'json':
+        r = client.http.get('/heartbeats')
+        click.echo(json.dumps(r['heartbeats'], sort_keys=True, indent=4, ensure_ascii=False))
+        sys.exit(0)
+
     timezone = obj['timezone']
     headers = {
         'id': 'ID', 'origin': 'ORIGIN', 'customer': 'CUSTOMER', 'tags': 'TAGS', 'createTime': 'CREATED',

--- a/alertaclient/commands/cmd_history.py
+++ b/alertaclient/commands/cmd_history.py
@@ -1,5 +1,8 @@
 
+import sys
 import click
+import json
+
 from tabulate import tabulate
 
 from alertaclient.utils import build_query
@@ -12,6 +15,12 @@ from alertaclient.utils import build_query
 def cli(obj, ids, filters):
     """Show status and severity changes for alerts."""
     client = obj['client']
+
+    if obj['output'] == 'json':
+        r = client.http.get('/alerts/history')
+        click.echo(json.dumps(r['history'], sort_keys=True, indent=4, ensure_ascii=False))
+        sys.exit(0)
+
     timezone = obj['timezone']
     if ids:
         query = [('id', x) for x in ids]

--- a/alertaclient/commands/cmd_keys.py
+++ b/alertaclient/commands/cmd_keys.py
@@ -1,5 +1,7 @@
 
+import sys
 import click
+import json
 
 from tabulate import tabulate
 
@@ -9,6 +11,12 @@ from tabulate import tabulate
 def cli(obj):
     """List API keys."""
     client = obj['client']
+
+    if obj['output'] == 'json':
+        r = client.http.get('/keys')
+        click.echo(json.dumps(r['keys'], sort_keys=True, indent=4, ensure_ascii=False))
+        sys.exit(0)
+
     timezone = obj['timezone']
     headers = {
         'id': 'ID', 'key': 'API KEY', 'user': 'USER', 'scopes': 'SCOPES', 'text': 'TEXT',

--- a/alertaclient/commands/cmd_perms.py
+++ b/alertaclient/commands/cmd_perms.py
@@ -1,6 +1,7 @@
 
-
+import sys
 import click
+import json
 
 from tabulate import tabulate
 
@@ -10,5 +11,11 @@ from tabulate import tabulate
 def cli(obj):
     """List permissions."""
     client = obj['client']
+
+    if obj['output'] == 'json':
+        r = client.http.get('/perms')
+        click.echo(json.dumps(r['permissions'], sort_keys=True, indent=4, ensure_ascii=False))
+        sys.exit(0)
+
     headers = {'id': 'ID', 'scopes': 'SCOPES', 'match': 'ROLE'}
     click.echo(tabulate([p.tabular() for p in client.get_perms()], headers=headers, tablefmt=obj['output']))

--- a/alertaclient/commands/cmd_query.py
+++ b/alertaclient/commands/cmd_query.py
@@ -1,4 +1,6 @@
 
+import sys
+import json
 import click
 from tabulate import tabulate
 
@@ -34,6 +36,11 @@ def cli(obj, ids, filters, display, from_date=None):
         query.append(('from-date', from_date))
 
     r = client.http.get('/alerts', query)
+
+    if obj['output'] == 'json':
+        print(json.dumps(r['alerts']))
+        sys.exit(0)
+
     alerts = [Alert.parse(a) for a in r['alerts']]
     last_time = r['lastTime']
     auto_refresh = r['autoRefresh']

--- a/alertaclient/commands/cmd_users.py
+++ b/alertaclient/commands/cmd_users.py
@@ -1,6 +1,7 @@
 
-
+import sys
 import click
+import json
 
 from tabulate import tabulate
 
@@ -10,6 +11,12 @@ from tabulate import tabulate
 def cli(obj):
     """List users."""
     client = obj['client']
+
+    if obj['output'] == 'json':
+        r = client.http.get('/users')
+        click.echo(json.dumps(r['users'], sort_keys=True, indent=4, ensure_ascii=False))
+        sys.exit(0)
+
     timezone = obj['timezone']
     headers = {'id': 'ID', 'name': 'USER', 'email': 'EMAIL', 'roles': 'ROLES', 'status': 'STATUS', 'text': 'TEXT',
                'createTime': 'CREATED', 'updateTime': 'LAST UPDATED', 'lastLogin': 'LAST LOGIN', 'email_verified': 'VERIFIED'}


### PR DESCRIPTION
```
$ alerta help
Usage: alerta [OPTIONS] COMMAND [ARGS]...

  Alerta client unified command-line tool.

Options:
  --config-file <FILE>  Configuration file.
  --profile <PROFILE>   Configuration profile.
  --endpoint-url <URL>  API endpoint URL.
  --output <FORMAT>     Output format. eg. simple, grid, psql, presto, rst
  --json                Output in JSON format. Shortcut for "--output json"
  --color / --no-color  Color-coded output based on severity.
  --debug               Debug mode.
  --help                Show this message and exit.
```