### PR TITLE
Added housekeeping command to CLI.

### DIFF
--- a/alertaclient/api.py
+++ b/alertaclient/api.py
@@ -265,6 +265,13 @@ class Client(object):
     def mgmt_status(self):
         return self.http.get('/management/status')
 
+    def housekeeping(self):
+        # This endpoint isn't currently JSON-encoded.
+        url = self.http.endpoint + "/management/housekeeping"
+        response = self.http.session.get(url, auth=self.http.auth, timeout=self.http.timeout)
+        if response.status_code != 200:
+            raise UnknownError(response.text)
+
 
 class ApiAuth(AuthBase):
 

--- a/alertaclient/commands/cmd_housekeeping.py
+++ b/alertaclient/commands/cmd_housekeeping.py
@@ -1,0 +1,9 @@
+import click
+
+
+@click.command('housekeeping', short_help='Expired and clears old alerts.')
+@click.pass_obj
+def cli(obj):
+    """Trigger the expiration and deletion of alerts."""
+    client = obj['client']
+    client.housekeeping()


### PR DESCRIPTION
This allows housekeeping to be triggered from inside the alerta client.

This isn't the cleanest way to do it because I'm working around the API not responding with JSON. I intend to submit a separate patch against alertad. I wanted to make something that was usable now rather than relying on someone running bleeding edge alertad.