### PR TITLE
Add support for blackout audit info

### DIFF
--- a/alertaclient/api.py
+++ b/alertaclient/api.py
@@ -126,7 +126,7 @@ class Client(object):
         return counts['services']
 
     # Blackouts
-    def create_blackout(self, environment, service=None, resource=None, event=None, group=None, tags=None, customer=None, start=None, duration=None):
+    def create_blackout(self, environment, service=None, resource=None, event=None, group=None, tags=None, customer=None, start=None, duration=None, text=None):
         data = {
             'environment': environment,
             'service': service or list(),
@@ -136,7 +136,8 @@ class Client(object):
             'tags': tags or list(),
             'customer': customer,
             'startTime': start,
-            'duration': duration
+            'duration': duration,
+            'text': text
         }
         r = self.http.post('/blackout', data)
         return Blackout.parse(r['blackout'])

--- a/alertaclient/commands/cmd_blackout.py
+++ b/alertaclient/commands/cmd_blackout.py
@@ -13,9 +13,10 @@ import click
 @click.option('--customer', metavar='STRING', help='Customer (Admin only)')
 @click.option('--start', metavar='DATETIME', help='Start time in ISO8601 eg. 2018-02-01T12:00:00.000Z')
 @click.option('--duration', metavar='SECONDS', type=int, help='Blackout period in seconds')
+@click.option('--text', help='Reason for blackout')
 @click.option('--delete', '-D', help='Delete blackout using ID')
 @click.pass_obj
-def cli(obj, environment, service, resource, event, group, tags, customer, start, duration, delete):
+def cli(obj, environment, service, resource, event, group, tags, customer, start, duration, text, delete):
     """Suppress alerts for specified duration based on alert attributes."""
     client = obj['client']
     if delete:
@@ -33,7 +34,8 @@ def cli(obj, environment, service, resource, event, group, tags, customer, start
                 tags=tags,
                 customer=customer,
                 start=start,
-                duration=duration
+                duration=duration,
+                text=text
             )
         except Exception as e:
             click.echo('ERROR: {}'.format(e))

--- a/alertaclient/commands/cmd_blackouts.py
+++ b/alertaclient/commands/cmd_blackouts.py
@@ -19,8 +19,9 @@ def cli(obj, purge):
         timezone = obj['timezone']
         headers = {
             'id': 'ID', 'priority': 'P', 'environment': 'ENVIRONMENT', 'service': 'SERVICE', 'resource': 'RESOURCE',
-            'event': 'EVENT', 'group': 'GROUP', 'tags': 'TAGS', 'startTime': 'START', 'endTime': 'END',
-            'duration': 'DURATION', 'status': 'STATUS', 'remaining': 'REMAINING', 'customer': 'CUSTOMER'
+            'event': 'EVENT', 'group': 'GROUP', 'tags': 'TAGS', 'customer': 'CUSTOMER', 'startTime': 'START', 'endTime': 'END',
+            'duration': 'DURATION', 'user': 'USER', 'createTime': 'CREATED', 'text': 'COMMENT',
+            'status': 'STATUS', 'remaining': 'REMAINING'
         }
         blackouts = client.get_blackouts()
         click.echo(tabulate([b.tabular(timezone) for b in blackouts], headers=headers, tablefmt=obj['output']))

--- a/alertaclient/models/blackout.py
+++ b/alertaclient/models/blackout.py
@@ -15,7 +15,7 @@ class Blackout(object):
             end_time = kwargs.get('end_time')
             duration = int((end_time - start_time).total_seconds())
         else:
-            duration = kwargs.get('duration', None) #or current_app.config['BLACKOUT_DURATION']
+            duration = kwargs.get('duration', None)
             end_time = start_time + timedelta(seconds=duration)
 
         self.id = kwargs.get('id', None)
@@ -29,6 +29,10 @@ class Blackout(object):
         self.start_time = start_time
         self.end_time = end_time
         self.duration = duration
+
+        self.user = kwargs.get('user', None)
+        self.create_time = kwargs.get('create_time', None)
+        self.text = kwargs.get('text', None)
 
         if self.environment:
             self.priority = 1
@@ -100,7 +104,10 @@ class Blackout(object):
             customer=json.get('customer', None),
             start_time=DateTime.parse(json.get('startTime')),
             end_time=DateTime.parse(json.get('endTime')),
-            duration=json.get('duration', None)
+            duration=json.get('duration', None),
+            user=json.get('user', None),
+            create_time=DateTime.parse(json.get('createTime')),
+            text=json.get('text', None)
         )
 
     def tabular(self, timezone=None):
@@ -118,5 +125,8 @@ class Blackout(object):
             'endTime': DateTime.localtime(self.end_time, timezone),
             'duration': '{}s'.format(self.duration),
             'status': self.status,
-            'remaining': '{}s'.format(self.remaining)
+            'remaining': '{}s'.format(self.remaining),
+            'user': self.user,
+            'createTime': DateTime.localtime(self.create_time, timezone),
+            'text': self.text
         }

--- a/tests/test_blackouts.py
+++ b/tests/test_blackouts.py
@@ -13,31 +13,33 @@ class BlackoutTestCase(unittest.TestCase):
 
         self.blackout = """
             {
-              "blackout": {
-                "customer": null,
-                "duration": 300,
-                "endTime": "2017-10-03T08:26:00.948Z",
-                "environment": "Production",
-                "event": "node_down",
-                "group": "Network",
-                "href": "http://localhost:8080/blackout/8eb1504f-cb48-433d-854c-b31e06284af9",
-                "id": "8eb1504f-cb48-433d-854c-b31e06284af9",
-                "priority": 3,
-                "remaining": 299,
-                "resource": "web01",
-                "service": [
-                  "Web",
-                  "App"
-                ],
-                "startTime": "2017-10-03T08:21:00.948Z",
-                "status": "active",
-                "tags": [
-                  "london",
-                  "linux"
-                ]
-              },
-              "id": "8eb1504f-cb48-433d-854c-b31e06284af9",
-              "status": "ok"
+                "blackout": {
+                    "createTime": "2018-08-26T20:45:04.622Z",
+                    "customer": null,
+                    "duration": 3600,
+                    "endTime": "2018-08-26T21:45:04.622Z",
+                    "environment": "Production",
+                    "event": null,
+                    "group": null,
+                    "href": "http://localhost:8080/blackout/e18a4be8-60d7-4ce2-9b3d-f18d814f7b85",
+                    "id": "e18a4be8-60d7-4ce2-9b3d-f18d814f7b85",
+                    "priority": 3,
+                    "remaining": 3599,
+                    "resource": null,
+                    "service": [
+                        "Network"
+                    ],
+                    "startTime": "2018-08-26T20:45:04.622Z",
+                    "status": "active",
+                    "tags": [
+                        "london",
+                        "linux"
+                    ],
+                    "text": "Network outage in Bracknell",
+                    "user": "admin@alerta.io"
+                },
+                "id": "e18a4be8-60d7-4ce2-9b3d-f18d814f7b85",
+                "status": "ok"
             }
         """
 
@@ -46,6 +48,7 @@ class BlackoutTestCase(unittest.TestCase):
         m.post('http://localhost:8080/blackout', text=self.blackout)
         alert = self.client.create_blackout(environment='Production', service=['Web', 'App'], resource='web01', event='node_down', group='Network', tags=["london", "linux"])
         self.assertEqual(alert.environment, 'Production')
-        self.assertEqual(alert.service, ['Web', 'App'])
-        self.assertEqual(alert.resource, 'web01')
+        self.assertEqual(alert.service, ['Network'])
         self.assertIn("london", alert.tags)
+        self.assertEqual(alert.text, 'Network outage in Bracknell')
+        self.assertEqual(alert.user, 'admin@alerta.io')


### PR DESCRIPTION
```
$ alerta blackouts
+--------------------------------------+-----+---------------+-----------+------------+---------+---------+--------+------------+---------------------+---------------------+------------+----------+-------------+-----------------+---------------------+-----------------------+
| ID                                   |   P | ENVIRONMENT   | SERVICE   | RESOURCE   | EVENT   | GROUP   | TAGS   | CUSTOMER   | START               | END                 | DURATION   | STATUS   | REMAINING   | USER            | CREATED             | COMMENT               |
|--------------------------------------+-----+---------------+-----------+------------+---------+---------+--------+------------+---------------------+---------------------+------------+----------+-------------+-----------------+---------------------+-----------------------|
| 96d91de7-f02f-41cc-9e62-350a6845286d |   3 | Production    | Up        |            | event   |         |        |            | 2018/08/23 21:34:35 | 2018/08/23 22:34:35 | 3600s      | expired  | 0s          | admin@alerta.io | 2018/08/23 21:34:35 |                       |
| 5a4b9976-935d-4f48-9270-bcc03f3f019a |   1 | Development   |           |            |         |         |        |            | 2018/08/26 20:28:24 | 2018/08/26 21:28:24 | 3600s      | active   | 1779s       | admin@alerta.io | 2018/08/26 20:28:24 | foo comment           |
| 0fac4534-c3d9-468a-b9a4-adb8f86e3dfb |   6 | Production    |           | res1       | ev1     |         |        |            | 2018/08/26 20:43:55 | 2018/08/26 21:43:55 | 3600s      | active   | 2711s       | admin@alerta.io | 2018/08/26 20:43:55 | lksdjfasldfj asdlfjas |
+--------------------------------------+-----+---------------+-----------+------------+---------+---------+--------+------------+---------------------+---------------------+------------+----------+-------------+-----------------+---------------------+-----------------------+
```

See alerta/alerta#585