### PR TITLE
Github OAuth only requires openid scope

### DIFF
--- a/alertaclient/auth/gitlab.py
+++ b/alertaclient/auth/gitlab.py
@@ -15,7 +15,7 @@ def login(client, gitlab_url, client_id):
         'response_type=code&'
         'client_id={client_id}&'
         'redirect_uri={redirect_uri}&'
-        'scope=openid%20api&'
+        'scope=openid&'
         'state={state}'
     ).format(
         gitlab_url=gitlab_url,


### PR DESCRIPTION
Following Alert API change https://github.com/alerta/alerta/pull/638 the only required scope is "openid".