### PR TITLE
Add paging to get_alerts and get_history

### DIFF
--- a/alertaclient/api.py
+++ b/alertaclient/api.py
@@ -95,15 +95,15 @@ class Client(object):
     def delete_alert(self, id):
         return self.http.delete('/alert/%s' % id)
 
-    def search(self, query=None):
-        return self.get_alerts(query)
+    def search(self, query=None, page=1, page_size=100):
+        return self.get_alerts(query, page, page_size)
 
-    def get_alerts(self, query=None):
-        r = self.http.get('/alerts', query)
+    def get_alerts(self, query=None, page=1, page_size=100):
+        r = self.http.get('/alerts', query, page=page, page_size=page_size)
         return [Alert.parse(a) for a in r['alerts']]
 
-    def get_history(self, query=None):
-        r = self.http.get('/alerts/history', query)
+    def get_history(self, query=None, page=1, page_size=100):
+        r = self.http.get('/alerts/history', query, page=page, page_size=page_size)
         return [RichHistory.parse(a) for a in r['history']]
 
     def get_count(self, query=None):
@@ -353,8 +353,13 @@ class HTTPClient(object):
 
         self.debug = debug
 
-    def get(self, path, query=None):
-        query = query or tuple()
+    def get(self, path, query=None, **kwargs):
+        query = query or []
+        if 'page' in kwargs:
+            query.append(('page', kwargs['page']))
+        if 'page_size' in kwargs:
+            query.append(('page-size', kwargs['page_size']))
+
         url = self.endpoint + path + '?' + urlencode(query, doseq=True)
         try:
             response = self.session.get(url, auth=self.auth, timeout=self.timeout)

--- a/alertaclient/commands/cmd_query.py
+++ b/alertaclient/commands/cmd_query.py
@@ -35,7 +35,7 @@ def cli(obj, ids, filters, display, from_date=None):
     if from_date:
         query.append(('from-date', from_date))
 
-    r = client.http.get('/alerts', query)
+    r = client.http.get('/alerts', query, page=1, page_size=1000)
 
     if obj['output'] == 'json':
         click.echo(json.dumps(r['alerts'], sort_keys=True, indent=4, ensure_ascii=False))


### PR DESCRIPTION
```
$ python
Python 3.7.0 (default, Aug 22 2018, 15:22:33)
[Clang 9.1.0 (clang-902.0.39.2)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from alertaclient.api import Client
>>> c = Client()
>>> c.get_history(page=4,page_size=1)
[RichHistory(id='4683d9a0-c61e-4355-a54a-94f005623ed1', environment='Production', resource='4c5fe456-944d-45cc-85d6-879d7e85d78f', event='869dea8b-d274-4554-8551-e5b08d19bef1', severity='warning', status=None, type='severity', customer=None)]
```

See https://github.com/alerta/alerta/pull/644