### PR TITLE
Add support for query string param to alert commands

### DIFF
--- a/alertaclient/commands/cmd_ack.py
+++ b/alertaclient/commands/cmd_ack.py
@@ -5,16 +5,20 @@ from alertaclient.utils import build_query
 
 @click.command('ack', short_help='Acknowledge alerts')
 @click.option('--ids', '-i', metavar='UUID', multiple=True, help='List of alert IDs (can use short 8-char id)')
+@click.option('--query', '-q', 'query', metavar='QUERY', help='severity:"warning" AND resource:web')
 @click.option('--filter', '-f', 'filters', metavar='FILTER', multiple=True, help='KEY=VALUE eg. serverity=warning resource=web')
 @click.option('--text', help='Message associated with status change')
 @click.pass_obj
-def cli(obj, ids, filters, text):
+def cli(obj, ids, query, filters, text):
     """Set alert status to 'ack'."""
     client = obj['client']
     if ids:
         total = len(ids)
     else:
-        query = build_query(filters)
+        if query:
+            query = [('q', query)]
+        else:
+            query = build_query(filters)
         total, _, _ = client.get_count(query)
         ids = [a.id for a in client.get_alerts(query)]
 

--- a/alertaclient/commands/cmd_action.py
+++ b/alertaclient/commands/cmd_action.py
@@ -8,16 +8,20 @@ from alertaclient.utils import build_query
 @click.command('action', short_help='Action alerts')
 @click.option('--action', '-a', metavar='ACTION', help='Custom action (user-defined)')
 @click.option('--ids', '-i', metavar='UUID', multiple=True, help='List of alert IDs (can use short 8-char id)')
+@click.option('--query', '-q', 'query', metavar='QUERY', help='severity:"warning" AND resource:web')
 @click.option('--filter', '-f', 'filters', metavar='FILTER', multiple=True, help='KEY=VALUE eg. serverity=warning resource=web')
 @click.option('--text', help='Message associated with action')
 @click.pass_obj
-def cli(obj, action, ids, filters, text):
+def cli(obj, action, ids, query, filters, text):
     """Take action on alert'."""
     client = obj['client']
     if ids:
         total = len(ids)
     else:
-        query = build_query(filters)
+        if query:
+            query = [('q', query)]
+        else:
+            query = build_query(filters)
         total, _, _ = client.get_count(query)
         ids = [a.id for a in client.get_alerts(query)]
 

--- a/alertaclient/commands/cmd_close.py
+++ b/alertaclient/commands/cmd_close.py
@@ -5,16 +5,20 @@ from alertaclient.utils import build_query
 
 @click.command('ack', short_help='Close alerts')
 @click.option('--ids', '-i', metavar='UUID', multiple=True, help='List of alert IDs (can use short 8-char id)')
+@click.option('--query', '-q', 'query', metavar='QUERY', help='severity:"warning" AND resource:web')
 @click.option('--filter', '-f', 'filters', metavar='FILTER', multiple=True, help='KEY=VALUE eg. serverity=warning resource=web')
 @click.option('--text', help='Message associated with status change')
 @click.pass_obj
-def cli(obj, ids, filters, text):
+def cli(obj, ids, query, filters, text):
     """Set alert status to 'closed'."""
     client = obj['client']
     if ids:
         total = len(ids)
     else:
-        query = build_query(filters)
+        if query:
+            query = [('q', query)]
+        else:
+            query = build_query(filters)
         total, _, _ = client.get_count(query)
         ids = [a.id for a in client.get_alerts(query)]
 

--- a/alertaclient/commands/cmd_delete.py
+++ b/alertaclient/commands/cmd_delete.py
@@ -5,17 +5,21 @@ from alertaclient.utils import build_query
 
 @click.command('delete', short_help='Delete alerts')
 @click.option('--ids', '-i', metavar='UUID', multiple=True, help='List of alert IDs (can use short 8-char id)')
+@click.option('--query', '-q', 'query', metavar='QUERY', help='severity:"warning" AND resource:web')
 @click.option('--filter', '-f', 'filters', metavar='FILTER', multiple=True, help='KEY=VALUE eg. serverity=warning resource=web')
 @click.pass_obj
-def cli(obj, ids, filters):
+def cli(obj, ids, query, filters):
     """Delete alerts."""
     client = obj['client']
     if ids:
         total = len(ids)
     else:
-        if not filters:
+        if not (query or filters):
             click.confirm('Deleting all alerts. Do you want to continue?', abort=True)
-        query = build_query(filters)
+        if query:
+            query = [('q', query)]
+        else:
+            query = build_query(filters)
         total, _, _ = client.get_count(query)
         ids = [a.id for a in client.get_alerts(query)]
 

--- a/alertaclient/commands/cmd_history.py
+++ b/alertaclient/commands/cmd_history.py
@@ -9,9 +9,10 @@ from alertaclient.utils import build_query
 
 @click.command('history', short_help='Show alert history')
 @click.option('--ids', '-i', metavar='UUID', multiple=True, help='List of alert IDs (can use short 8-char id)')
+@click.option('--query', '-q', 'query', metavar='QUERY', help='severity:"warning" AND resource:web')
 @click.option('--filter', '-f', 'filters', metavar='FILTER', multiple=True, help='KEY=VALUE eg. serverity=warning resource=web')
 @click.pass_obj
-def cli(obj, ids, filters):
+def cli(obj, ids, query, filters):
     """Show status and severity changes for alerts."""
     client = obj['client']
 
@@ -22,6 +23,8 @@ def cli(obj, ids, filters):
         timezone = obj['timezone']
         if ids:
             query = [('id', x) for x in ids]
+        elif query:
+            query = [('q', query)]
         else:
             query = build_query(filters)
         alerts = client.get_history(query)

--- a/alertaclient/commands/cmd_query.py
+++ b/alertaclient/commands/cmd_query.py
@@ -19,17 +19,20 @@ COLOR_MAP = {
 
 @click.command('query', short_help='Search for alerts')
 @click.option('--ids', '-i', metavar='UUID', multiple=True, help='List of alert IDs (can use short 8-char id)')
+@click.option('--query', '-q', 'query', metavar='QUERY', help='severity:"warning" AND resource:web')
 @click.option('--filter', '-f', 'filters', metavar='FILTER', multiple=True, help='KEY=VALUE eg. serverity=warning resource=web')
 @click.option('--tabular', 'display', flag_value='tabular', default=True, help='Tabular output')
 @click.option('--compact', 'display', flag_value='compact', help='Compact output')
 @click.option('--details', 'display', flag_value='details', help='Compact output with details')
 @click.pass_obj
-def cli(obj, ids, filters, display, from_date=None):
+def cli(obj, ids, query, filters, display, from_date=None):
     """Query for alerts based on search filter criteria."""
     client = obj['client']
     timezone = obj['timezone']
     if ids:
         query = [('id', x) for x in ids]
+    elif query:
+        query = [('q', query)]
     else:
         query = build_query(filters)
     if from_date:

--- a/alertaclient/commands/cmd_raw.py
+++ b/alertaclient/commands/cmd_raw.py
@@ -7,13 +7,16 @@ from alertaclient.utils import build_query
 
 @click.command('raw', short_help='Show alert raw data')
 @click.option('--ids', '-i', metavar='UUID', multiple=True, help='List of alert IDs (can use short 8-char id)')
+@click.option('--query', '-q', 'query', metavar='QUERY', help='severity:"warning" AND resource:web')
 @click.option('--filter', '-f', 'filters', metavar='FILTER', multiple=True, help='KEY=VALUE eg. serverity=warning resource=web')
 @click.pass_obj
-def cli(obj, ids, filters):
+def cli(obj, ids, query, filters):
     """Show raw data for alerts."""
     client = obj['client']
     if ids:
         query = [('id', x) for x in ids]
+    elif query:
+        query = [('q', query)]
     else:
         query = build_query(filters)
     alerts = client.search(query)

--- a/alertaclient/commands/cmd_shelve.py
+++ b/alertaclient/commands/cmd_shelve.py
@@ -5,16 +5,20 @@ from alertaclient.utils import build_query
 
 @click.command('shelve', short_help='Shelve alerts')
 @click.option('--ids', '-i', metavar='UUID', multiple=True, help='List of alert IDs (can use short 8-char id)')
+@click.option('--query', '-q', 'query', metavar='QUERY', help='severity:"warning" AND resource:web')
 @click.option('--filter', '-f', 'filters', metavar='FILTER', multiple=True, help='KEY=VALUE eg. serverity=warning resource=web')
 @click.option('--text', help='Message associated with status change')
 @click.pass_obj
-def cli(obj, ids, filters, text):
+def cli(obj, ids, query, filters, text):
     """Set alert status to 'shelved'."""
     client = obj['client']
     if ids:
         total = len(ids)
     else:
-        query = build_query(filters)
+        if query:
+            query = [('q', query)]
+        else:
+            query = build_query(filters)
         total, _, _ = client.get_count(query)
         ids = [a.id for a in client.get_alerts(query)]
 

--- a/alertaclient/commands/cmd_tag.py
+++ b/alertaclient/commands/cmd_tag.py
@@ -5,16 +5,20 @@ from alertaclient.utils import build_query
 
 @click.command('tag', short_help='Tag alerts')
 @click.option('--ids', '-i', metavar='UUID', multiple=True, help='List of alert IDs (can use short 8-char id)')
+@click.option('--query', '-q', 'query', metavar='QUERY', help='severity:"warning" AND resource:web')
 @click.option('--filter', '-f', 'filters', metavar='FILTER', multiple=True, help='KEY=VALUE eg. serverity=warning resource=web')
 @click.option('--tag', '-T', 'tags', required=True, multiple=True, help='List of tags')
 @click.pass_obj
-def cli(obj, ids, filters, tags):
+def cli(obj, ids, query, filters, tags):
     """Add tags to alerts."""
     client = obj['client']
     if ids:
         total = len(ids)
     else:
-        query = build_query(filters)
+        if query:
+            query = [('q', query)]
+        else:
+            query = build_query(filters)
         total, _, _ = client.get_count(query)
         ids = [a.id for a in client.get_alerts(query)]
 

--- a/alertaclient/commands/cmd_unack.py
+++ b/alertaclient/commands/cmd_unack.py
@@ -5,16 +5,20 @@ from alertaclient.utils import build_query
 
 @click.command('unack', short_help='Un-acknowledge alerts')
 @click.option('--ids', '-i', metavar='UUID', multiple=True, help='List of alert IDs (can use short 8-char id)')
+@click.option('--query', '-q', 'query', metavar='QUERY', help='severity:"warning" AND resource:web')
 @click.option('--filter', '-f', 'filters', metavar='FILTER', multiple=True, help='KEY=VALUE eg. serverity=warning resource=web')
 @click.option('--text', help='Message associated with status change')
 @click.pass_obj
-def cli(obj, ids, filters, text):
+def cli(obj, ids, query, filters, text):
     """Set alert status to 'open'."""
     client = obj['client']
     if ids:
         total = len(ids)
     else:
-        query = build_query(filters)
+        if query:
+            query = [('q', query)]
+        else:
+            query = build_query(filters)
         total, _, _ = client.get_count(query)
         ids = [a.id for a in client.get_alerts(query)]
 

--- a/alertaclient/commands/cmd_unshelve.py
+++ b/alertaclient/commands/cmd_unshelve.py
@@ -5,16 +5,20 @@ from alertaclient.utils import build_query
 
 @click.command('unshelve', short_help='Un-shelve alerts')
 @click.option('--ids', '-i', metavar='UUID', multiple=True, help='List of alert IDs (can use short 8-char id)')
+@click.option('--query', '-q', 'query', metavar='QUERY', help='severity:"warning" AND resource:web')
 @click.option('--filter', '-f', 'filters', metavar='FILTER', multiple=True, help='KEY=VALUE eg. serverity=warning resource=web')
 @click.option('--text', help='Message associated with status change')
 @click.pass_obj
-def cli(obj, ids, filters, text):
+def cli(obj, ids, query, filters, text):
     """Set alert status to 'open'."""
     client = obj['client']
     if ids:
         total = len(ids)
     else:
-        query = build_query(filters)
+        if query:
+            query = [('q', query)]
+        else:
+            query = build_query(filters)
         total, _, _ = client.get_count(query)
         ids = [a.id for a in client.get_alerts(query)]
 

--- a/alertaclient/commands/cmd_untag.py
+++ b/alertaclient/commands/cmd_untag.py
@@ -5,16 +5,20 @@ from alertaclient.utils import build_query
 
 @click.command('untag', short_help='Untag alerts')
 @click.option('--ids', '-i', metavar='UUID', multiple=True, help='List of alert IDs (can use short 8-char id)')
+@click.option('--query', '-q', 'query', metavar='QUERY', help='severity:"warning" AND resource:web')
 @click.option('--filter', '-f', 'filters', metavar='FILTER', multiple=True, help='KEY=VALUE eg. serverity=warning resource=web')
 @click.option('--tag', '-T', 'tags', required=True, multiple=True, help='List of tags')
 @click.pass_obj
-def cli(obj, ids, filters, tags):
+def cli(obj, ids, query, filters, tags):
     """Remove tags from alerts."""
     client = obj['client']
     if ids:
         total = len(ids)
     else:
-        query = build_query(filters)
+        if query:
+            query = [('q', query)]
+        else:
+            query = build_query(filters)
         total, _, _ = client.get_count(query)
         ids = [a.id for a in client.get_alerts(query)]
 

--- a/alertaclient/commands/cmd_update.py
+++ b/alertaclient/commands/cmd_update.py
@@ -5,16 +5,20 @@ from alertaclient.utils import build_query
 
 @click.command('update', short_help='Update alert attributes')
 @click.option('--ids', '-i', metavar='UUID', multiple=True, help='List of alert IDs (can use short 8-char id)')
+@click.option('--query', '-q', 'query', metavar='QUERY', help='severity:"warning" AND resource:web')
 @click.option('--filter', '-f', 'filters', metavar='FILTER', multiple=True, help='KEY=VALUE eg. serverity=warning resource=web')
 @click.option('--attributes', '-A', metavar='KEY=VALUE', multiple=True, required=True, help='List of attributes eg. priority=high')
 @click.pass_obj
-def cli(obj, ids, filters, attributes):
+def cli(obj, ids, query, filters, attributes):
     """Update alert attributes."""
     client = obj['client']
     if ids:
         total = len(ids)
     else:
-        query = build_query(filters)
+        if query:
+            query = [('q', query)]
+        else:
+            query = build_query(filters)
         total, _, _ = client.get_count(query)
         ids = [a.id for a in client.get_alerts(query)]
 

--- a/alertaclient/commands/cmd_watch.py
+++ b/alertaclient/commands/cmd_watch.py
@@ -4,16 +4,17 @@ import time
 
 import click
 
-from .cmd_query import cli as query
+from .cmd_query import cli as query_cmd
 
 
 @click.command('watch', short_help='Watch alerts')
 @click.option('--ids', '-i', metavar='UUID', multiple=True, help='List of alert IDs (can use short 8-char id)')
+@click.option('--query', '-q', 'query', metavar='QUERY', help='severity:"warning" AND resource:web')
 @click.option('--filter', '-f', 'filters', metavar='FILTER', multiple=True, help='KEY=VALUE eg. serverity=warning resource=web')
 @click.option('--details', is_flag=True, help='Compact output with details')
 @click.option('--interval', '-n', metavar='SECONDS', type=int, default=2, help='Refresh interval')
 @click.pass_context
-def cli(ctx, ids, filters, details, interval):
+def cli(ctx, ids, query, filters, details, interval):
     """Watch for new alerts."""
     if details:
         display = 'details'
@@ -24,7 +25,8 @@ def cli(ctx, ids, filters, details, interval):
     auto_refresh = True
     while auto_refresh:
         try:
-            auto_refresh, from_date = ctx.invoke(query, ids=ids, filters=filters, display=display, from_date=from_date)
+            auto_refresh, from_date = ctx.invoke(query_cmd, ids=ids, query=query,
+                                                 filters=filters, display=display, from_date=from_date)
             time.sleep(interval)
         except (KeyboardInterrupt, SystemExit) as e:
             sys.exit(e)


### PR DESCRIPTION

**Examples**
```
$ alerta query -q '(quick brown) AND fox'
$ alerta query -q 'group:"John Smith"'
$ alerta query -q '_exists_:region'
$ alerta query -q 'status:(open ack)'
$ alerta query -q 'te?t'
$ alerta query -q '/quick.* fox/'
```

See https://github.com/alerta/alerta/pull/712