### PR TITLE
Revert "Allow local config exclusions to prevent remote override"

### DIFF
--- a/alertaclient/config.py
+++ b/alertaclient/config.py
@@ -14,7 +14,6 @@ default_config = {
     'timezone': 'Europe/London',
     'timeout': 5.0,
     'sslverify': True,
-    'use_local': [],  # eg. set to ['endpoint'] to prevent server override
     'output': 'simple',
     'color': True,
     'debug': False
@@ -53,8 +52,4 @@ class Config:
         except requests.RequestException as e:
             raise
 
-        # remove local exclusions from remote config
-        remote_config_only = {k: v for k, v in remote_config.items() if k not in self.options['use_local']}
-
-        # merge local config with remote, giving precedence to remote
-        self.options = {**self.options, **remote_config_only}
+        self.options = {**self.options, **remote_config}


### PR DESCRIPTION
Reverts alerta/python-alerta-client#157

After giving this some thought I think it better to reverse the precedence and give local config higher precedence over remote config. It's less surprising to the end user, I think.