### PR TITLE
Allow OAuth2 client id to be configured locally

### DIFF
--- a/alertaclient/config.py
+++ b/alertaclient/config.py
@@ -9,6 +9,7 @@ default_config = {
     'profile': None,
     'endpoint': 'http://localhost:8080',
     'key': '',
+    'client_id': None,
     'username': None,
     'password': None,
     'timezone': 'Europe/London',


### PR DESCRIPTION
It must be able to override the OAuth2 client id locally so that github users can login on both web and CLI clients using different OAuth2 client ids. See https://github.com/alerta/alerta/pull/512#issuecomment-441198354