### PR TITLE
fixed python-alerta-client on Windows

### DIFF
--- a/alertaclient/auth/utils.py
+++ b/alertaclient/auth/utils.py
@@ -5,7 +5,7 @@ from urllib.parse import urlparse
 
 from alertaclient.exceptions import ConfigurationError
 
-NETRC_FILE = os.path.join(os.environ['HOME'], '.netrc')
+NETRC_FILE = os.path.join(os.path.expanduser('~'), '.netrc')
 
 
 def machine(endpoint):


### PR DESCRIPTION
I failed to run alerta client on Windows 10, since there is no `HOME` env on Windows:

```
>alerta users
Traceback (most recent call last):
  File "C:\temp\repos\python-alerta-client\venv\Scripts\alerta-script.py", line 11, in <module>
    load_entry_point('alerta==6.5.0', 'console_scripts', 'alerta')()
  File "C:\temp\repos\python-alerta-client\venv\lib\site-packages\pkg_resources\__init__.py", line 487, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "C:\temp\repos\python-alerta-client\venv\lib\site-packages\pkg_resources\__init__.py", line 2728, in load_entry_point
    return ep.load()
  File "C:\temp\repos\python-alerta-client\venv\lib\site-packages\pkg_resources\__init__.py", line 2346, in load
    return self.resolve()
  File "C:\temp\repos\python-alerta-client\venv\lib\site-packages\pkg_resources\__init__.py", line 2352, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "C:\temp\repos\python-alerta-client\venv\lib\site-packages\alerta-6.5.0-py3.7.egg\alertaclient\cli.py", line 7, in <module>
    from alertaclient.auth.utils import get_token
  File "C:\temp\repos\python-alerta-client\venv\lib\site-packages\alerta-6.5.0-py3.7.egg\alertaclient\auth\utils.py", line 8, in <module>
    NETRC_FILE = os.path.join(os.environ['HOME'], '.netrc')
  File "C:\Program Files\Python37\lib\os.py", line 678, in __getitem__
    raise KeyError(key) from None
KeyError: 'HOME'
```
In order to run the client on Win, I changed HOME env to platform independent `os.path.expanduser('~')`
https://docs.python.org/3.5/library/os.path.html#os.path.expanduser
