### PR TITLE
alerta top: ensure text_width is >= 0, otherwise top.py can fail with ValueError: Format specifier missing precision

### DIFF
--- a/alertaclient/top.py
+++ b/alertaclient/top.py
@@ -91,7 +91,7 @@ class Screen:
         # TODO - draw bars
 
         # draw alerts
-        text_width = self.cols - 95
+        text_width = self.cols - 95 if self.cols >= 95 else 0
         self._addstr(2, 1, 'Sev. Time     Dupl. Customer Env.         Service      Resource     Group Event' +
                      '        Value Text' + ' ' * (text_width - 4), curses.A_UNDERLINE)
 


### PR DESCRIPTION
if terminal has less than 95 columns then alerta top will fail:
alertaclient/top.py", line 125, in update
    width=text_width
ValueError: Format specifier missing precision
