### PR TITLE
Set `resource` and `service` from Hearbeat tags

### DIFF
--- a/alertaclient/commands/cmd_heartbeats.py
+++ b/alertaclient/commands/cmd_heartbeats.py
@@ -70,12 +70,12 @@ def cli(obj, alert, severity, timeout, purge):
                     )
                 elif b.status == 'slow':
                     client.send_alert(
-                        resource=b.origin,
+                        resource=resource,
                         event='HeartbeatSlow',
                         correlate=['HeartbeatFail', 'HeartbeatSlow', 'HeartbeatOK'],
                         group=group,
                         environment=environment,
-                        service=['Alerta'],
+                        service=[service],
                         severity=severity,
                         value='{}ms'.format(b.latency),
                         text='Heartbeat took more than {}ms to be processed'.format(MAX_LATENCY),
@@ -86,12 +86,12 @@ def cli(obj, alert, severity, timeout, purge):
                     )
                 else:
                     client.send_alert(
-                        resource=b.origin,
+                        resource=resource,
                         event='HeartbeatOK',
                         correlate=['HeartbeatFail', 'HeartbeatSlow', 'HeartbeatOK'],
                         group=group,
                         environment=environment,
-                        service=['Alerta'],
+                        service=[service],
                         severity=default_normal_severity,
                         value='',
                         text='Heartbeat OK',

--- a/alertaclient/commands/cmd_heartbeats.py
+++ b/alertaclient/commands/cmd_heartbeats.py
@@ -47,17 +47,19 @@ def cli(obj, alert, severity, timeout, purge):
                 params = dict(filter(lambda a: len(a) == 2, map(lambda a: a.split(':'), b.tags)))
                 environment = params.get('environment', 'Production')
                 group = params.get('group', 'System')
+                service = params.get('service','Alerta')
+                resource = params.get('resource',b.origin)
                 tags = list(filter(lambda a: not a.startswith('environment:')
                                    and not a.startswith('group:'), b.tags))
 
                 if b.status == 'expired':  # aka. "stale"
                     client.send_alert(
-                        resource=b.origin,
+                        resource=resource,
                         event='HeartbeatFail',
                         correlate=['HeartbeatFail', 'HeartbeatSlow', 'HeartbeatOK'],
                         group=group,
                         environment=environment,
-                        service=['Alerta'],
+                        service=[service],
                         severity=severity,
                         value='{}'.format(b.since),
                         text='Heartbeat not received in {} seconds'.format(b.timeout),


### PR DESCRIPTION
Adding the possibility to set the `resource` or `service` of an Alert generated from a stale Heartbeat 