### PR TITLE
rename wheel to alertaclient

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def read(filename):
 
 
 setuptools.setup(
-    name='alerta',
+    name='alertaclient',
     version=read('VERSION'),
     description='Alerta unified command-line tool and SDK',
     long_description=read('README.md'),


### PR DESCRIPTION
This PR renames the python package wheel from `alerta` to `alertaclient`
At the moment by running: `python setup.py bdist_wheel` a wheel is created `dist/alerta-7.4.0-py2.py3-none-any.whl`

This PR will change this output to `dist/alertaclient-7.4.0-py2.py3-none-any.whl` and python package name is in sync with the wheel name, i.e. `import alertaclient` and `pip install alertaclient`.