### PR TITLE
Use heartbeat attributes for heartbeat alert details

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,6 @@ repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks.git
     rev: v1.4.0
     hooks:
-    -   id: autopep8-wrapper
     -   id: check-added-large-files
     -   id: check-ast
     -   id: check-byte-order-marker
@@ -23,16 +22,20 @@ repos:
         args: ['--django']
     -   id: requirements-txt-fixer
     -   id: trailing-whitespace
+-   repo: https://github.com/pre-commit/mirrors-autopep8
+    rev: v1.5
+    hooks:
+    -   id: autopep8
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v1.6.1
+    rev: v1.26.2
     hooks:
     -   id: pyupgrade
         args: ['--py3-plus']
 -   repo: https://github.com/asottile/seed-isort-config
-    rev: v1.2.0
+    rev: v1.9.4
     hooks:
     -   id: seed-isort-config
 -   repo: https://github.com/pre-commit/mirrors-isort
-    rev: v4.3.4
+    rev: v4.3.21
     hooks:
     -   id: isort

--- a/alertaclient/api.py
+++ b/alertaclient/api.py
@@ -1,4 +1,3 @@
-
 import json
 import logging
 import os

--- a/alertaclient/api.py
+++ b/alertaclient/api.py
@@ -200,10 +200,11 @@ class Client:
         return self.http.delete('/customer/%s' % id)
 
     # Heartbeats
-    def heartbeat(self, origin, tags=None, timeout=None, customer=None):
+    def heartbeat(self, origin, tags=None, attributes=None, timeout=None, customer=None):
         data = {
             'origin': origin,
             'tags': tags or list(),
+            'attributes': attributes or dict(),
             'timeout': timeout,
             'createTime': datetime.utcnow(),
             'customer': customer

--- a/alertaclient/auth/azure.py
+++ b/alertaclient/auth/azure.py
@@ -1,4 +1,3 @@
-
 import webbrowser
 from uuid import uuid4
 

--- a/alertaclient/auth/github.py
+++ b/alertaclient/auth/github.py
@@ -1,4 +1,3 @@
-
 import webbrowser
 from uuid import uuid4
 

--- a/alertaclient/auth/gitlab.py
+++ b/alertaclient/auth/gitlab.py
@@ -1,4 +1,3 @@
-
 import webbrowser
 from uuid import uuid4
 

--- a/alertaclient/auth/google.py
+++ b/alertaclient/auth/google.py
@@ -1,4 +1,3 @@
-
 import webbrowser
 from uuid import uuid4
 

--- a/alertaclient/auth/oidc.py
+++ b/alertaclient/auth/oidc.py
@@ -1,4 +1,3 @@
-
 import webbrowser
 from uuid import uuid4
 

--- a/alertaclient/auth/token.py
+++ b/alertaclient/auth/token.py
@@ -1,4 +1,3 @@
-
 import base64
 import json
 from http.server import BaseHTTPRequestHandler, HTTPServer

--- a/alertaclient/auth/utils.py
+++ b/alertaclient/auth/utils.py
@@ -1,4 +1,3 @@
-
 import os
 from netrc import netrc
 from urllib.parse import urlparse

--- a/alertaclient/commands/cmd_blackouts.py
+++ b/alertaclient/commands/cmd_blackouts.py
@@ -1,4 +1,3 @@
-
 import json
 
 import click

--- a/alertaclient/commands/cmd_config.py
+++ b/alertaclient/commands/cmd_config.py
@@ -1,4 +1,3 @@
-
 import click
 
 

--- a/alertaclient/commands/cmd_customers.py
+++ b/alertaclient/commands/cmd_customers.py
@@ -1,4 +1,3 @@
-
 import json
 
 import click

--- a/alertaclient/commands/cmd_groups.py
+++ b/alertaclient/commands/cmd_groups.py
@@ -1,4 +1,3 @@
-
 import json
 
 import click

--- a/alertaclient/commands/cmd_heartbeat.py
+++ b/alertaclient/commands/cmd_heartbeat.py
@@ -1,27 +1,47 @@
-import os
-import platform
 import sys
 
 import click
 
-prog = os.path.basename(sys.argv[0])
+from alertaclient.utils import origin
 
 
 @click.command('heartbeat', short_help='Send a heartbeat')
-@click.option('--origin', '-O', metavar='ORIGIN', default='{}/{}'.format(prog, platform.uname()[1]), help='Origin of heartbeat.')
+@click.option('--origin', '-O', metavar='ORIGIN', default=origin, help='Origin of heartbeat.')
+@click.option('--environment', '-E', metavar='ENVIRONMENT', help='Environment eg. Production, Development')
+@click.option('--severity', '-s', metavar='SEVERITY', help='Severity eg. critical, major, minor, warning')
+@click.option('--service', '-S', metavar='SERVICE', multiple=True, help='List of affected services eg. app name, Web, Network, Storage, Database, Security')
+@click.option('--group', '-g', metavar='GROUP', help='Group event by type eg. OS, Performance')
 @click.option('--tag', '-T', 'tags', multiple=True, metavar='TAG', help='List of tags eg. London, os:linux, AWS/EC2')
 @click.option('--timeout', metavar='SECONDS', type=int, help='Seconds before heartbeat is stale')
 @click.option('--customer', metavar='STRING', help='Customer')
 @click.option('--delete', '-D', metavar='ID', help='Delete hearbeat using ID')
 @click.pass_obj
-def cli(obj, origin, tags, timeout, customer, delete):
-    """Send or delete a heartbeat."""
+def cli(obj, origin, environment, severity, service, group, tags, timeout, customer, delete):
+    """
+    Send or delete a heartbeat.
+
+    Note: The "environment", "severity", "service" and "group" values are only
+    used when heartbeat alerts are generated from slow or stale heartbeats.
+    """
     client = obj['client']
     if delete:
         client.delete_heartbeat(delete)
     else:
+        if any(t.startswith('environment') or t.startswith('group') for t in tags):
+            click.secho('ERROR: Do not use tags for "environment" or "group". See help.', bold=True)
+
+        attributes = dict()
+        if environment:
+            attributes['environment'] = environment
+        if severity:
+            attributes['severity'] = severity
+        if service:
+            attributes['service'] = service
+        if group:
+            attributes['group'] = group
+
         try:
-            heartbeat = client.heartbeat(origin=origin, tags=tags, timeout=timeout, customer=customer)
+            heartbeat = client.heartbeat(origin=origin, tags=tags, attributes=attributes, timeout=timeout, customer=customer)
         except Exception as e:
             click.echo('ERROR: {}'.format(e))
             sys.exit(1)

--- a/alertaclient/commands/cmd_help.py
+++ b/alertaclient/commands/cmd_help.py
@@ -1,4 +1,3 @@
-
 import click
 
 

--- a/alertaclient/commands/cmd_history.py
+++ b/alertaclient/commands/cmd_history.py
@@ -1,4 +1,3 @@
-
 import json
 
 import click

--- a/alertaclient/commands/cmd_keys.py
+++ b/alertaclient/commands/cmd_keys.py
@@ -1,4 +1,3 @@
-
 import json
 
 import click

--- a/alertaclient/commands/cmd_login.py
+++ b/alertaclient/commands/cmd_login.py
@@ -1,4 +1,3 @@
-
 import sys
 
 import click

--- a/alertaclient/commands/cmd_logout.py
+++ b/alertaclient/commands/cmd_logout.py
@@ -1,4 +1,3 @@
-
 import click
 
 from alertaclient.auth.utils import clear_token

--- a/alertaclient/commands/cmd_perms.py
+++ b/alertaclient/commands/cmd_perms.py
@@ -1,4 +1,3 @@
-
 import json
 
 import click

--- a/alertaclient/commands/cmd_query.py
+++ b/alertaclient/commands/cmd_query.py
@@ -1,4 +1,3 @@
-
 import json
 
 import click
@@ -97,7 +96,7 @@ def cli(obj, ids, query, filters, display, from_date=None):
                         DateTime.localtime(alert.receive_time, timezone)), fg=color['fg'])
                     click.secho('        last received | {}'.format(
                         DateTime.localtime(alert.last_receive_time, timezone)), fg=color['fg'])
-                    click.secho('        latency       | {}ms'.format((latency.microseconds / 1000)), fg=color['fg'])
+                    click.secho('        latency       | {}ms'.format(latency.microseconds / 1000), fg=color['fg'])
                     click.secho('        timeout       | {}s'.format(alert.timeout), fg=color['fg'])
 
                     click.secho('            alert id     | {}'.format(alert.id), fg=color['fg'])

--- a/alertaclient/commands/cmd_raw.py
+++ b/alertaclient/commands/cmd_raw.py
@@ -1,4 +1,3 @@
-
 import click
 from tabulate import tabulate
 

--- a/alertaclient/commands/cmd_send.py
+++ b/alertaclient/commands/cmd_send.py
@@ -1,4 +1,3 @@
-
 import json
 import os
 import sys
@@ -29,6 +28,7 @@ def cli(obj, resource, event, environment, severity, correlate, service, group, 
     client = obj['client']
 
     def send_alert(resource, event, **kwargs):
+        click.echo('send')
         try:
             id, alert, message = client.send_alert(
                 resource=resource,

--- a/alertaclient/commands/cmd_status.py
+++ b/alertaclient/commands/cmd_status.py
@@ -1,4 +1,3 @@
-
 import click
 from tabulate import tabulate
 

--- a/alertaclient/commands/cmd_token.py
+++ b/alertaclient/commands/cmd_token.py
@@ -1,4 +1,3 @@
-
 import click
 
 from alertaclient.auth.utils import get_token

--- a/alertaclient/commands/cmd_top.py
+++ b/alertaclient/commands/cmd_top.py
@@ -1,4 +1,3 @@
-
 import click
 
 from alertaclient.top import Screen

--- a/alertaclient/commands/cmd_uptime.py
+++ b/alertaclient/commands/cmd_uptime.py
@@ -1,4 +1,3 @@
-
 from datetime import datetime, timedelta
 
 import click

--- a/alertaclient/commands/cmd_users.py
+++ b/alertaclient/commands/cmd_users.py
@@ -1,4 +1,3 @@
-
 import json
 
 import click

--- a/alertaclient/commands/cmd_version.py
+++ b/alertaclient/commands/cmd_version.py
@@ -1,4 +1,3 @@
-
 import click
 from requests import __version__ as requests_version
 

--- a/alertaclient/commands/cmd_watch.py
+++ b/alertaclient/commands/cmd_watch.py
@@ -1,4 +1,3 @@
-
 import sys
 import time
 

--- a/alertaclient/commands/cmd_whoami.py
+++ b/alertaclient/commands/cmd_whoami.py
@@ -1,4 +1,3 @@
-
 import click
 
 

--- a/alertaclient/exceptions.py
+++ b/alertaclient/exceptions.py
@@ -1,4 +1,3 @@
-
 try:
     from click import ClickException as ClientException  # type: ignore
 except Exception:

--- a/alertaclient/models/alert.py
+++ b/alertaclient/models/alert.py
@@ -1,4 +1,3 @@
-
 from datetime import datetime
 
 from alertaclient.utils import DateTime

--- a/alertaclient/models/blackout.py
+++ b/alertaclient/models/blackout.py
@@ -1,4 +1,3 @@
-
 from datetime import datetime, timedelta
 
 from alertaclient.utils import DateTime

--- a/alertaclient/models/customer.py
+++ b/alertaclient/models/customer.py
@@ -1,4 +1,3 @@
-
 class Customer:
 
     def __init__(self, match, customer, **kwargs):

--- a/alertaclient/models/group.py
+++ b/alertaclient/models/group.py
@@ -1,4 +1,3 @@
-
 from typing import Any, Dict
 from uuid import uuid4
 

--- a/alertaclient/models/heartbeat.py
+++ b/alertaclient/models/heartbeat.py
@@ -1,4 +1,3 @@
-
 from datetime import datetime, timedelta
 
 from alertaclient.utils import DateTime

--- a/alertaclient/models/heartbeat.py
+++ b/alertaclient/models/heartbeat.py
@@ -9,10 +9,15 @@ DEFAULT_MAX_LATENCY = 2000  # ms
 class Heartbeat:
 
     def __init__(self, origin=None, tags=None, create_time=None, timeout=None, customer=None, **kwargs):
+        if any(['.' in key for key in kwargs.get('attributes', dict()).keys()])\
+                or any(['$' in key for key in kwargs.get('attributes', dict()).keys()]):
+            raise ValueError('Attribute keys must not contain "." or "$"')
+
         self.id = kwargs.get('id', None)
         self.origin = origin
         self.status = kwargs.get('status', None) or 'unknown'
         self.tags = tags or list()
+        self.attributes = kwargs.get('attributes', None) or dict()
         self.event_type = kwargs.get('event_type', kwargs.get('type', None)) or 'Heartbeat'
         self.create_time = create_time
         self.timeout = timeout
@@ -37,6 +42,8 @@ class Heartbeat:
     def parse(cls, json):
         if not isinstance(json.get('tags', []), list):
             raise ValueError('tags must be a list')
+        if not isinstance(json.get('attributes', {}), dict):
+            raise ValueError('attributes must be a JSON object')
         if not isinstance(json.get('timeout', 0), int):
             raise ValueError('timeout must be an integer')
 
@@ -45,6 +52,7 @@ class Heartbeat:
             origin=json.get('origin', None),
             status=json.get('status', None),
             tags=json.get('tags', list()),
+            attributes=json.get('attributes', dict()),
             event_type=json.get('type', None),
             create_time=DateTime.parse(json.get('createTime')),
             timeout=json.get('timeout', None),
@@ -59,6 +67,7 @@ class Heartbeat:
             'origin': self.origin,
             'customer': self.customer,
             'tags': ','.join(self.tags),
+            'attributes': self.attributes,
             'createTime': DateTime.localtime(self.create_time, timezone),
             'receiveTime': DateTime.localtime(self.receive_time, timezone),
             'since': self.since,

--- a/alertaclient/models/history.py
+++ b/alertaclient/models/history.py
@@ -1,4 +1,3 @@
-
 from datetime import datetime
 
 from alertaclient.utils import DateTime

--- a/alertaclient/models/key.py
+++ b/alertaclient/models/key.py
@@ -1,4 +1,3 @@
-
 from alertaclient.utils import DateTime
 
 

--- a/alertaclient/models/permission.py
+++ b/alertaclient/models/permission.py
@@ -1,5 +1,3 @@
-
-
 class Permission:
 
     def __init__(self, match, scopes, **kwargs):

--- a/alertaclient/models/user.py
+++ b/alertaclient/models/user.py
@@ -1,4 +1,3 @@
-
 from alertaclient.utils import DateTime
 
 

--- a/alertaclient/top.py
+++ b/alertaclient/top.py
@@ -1,4 +1,3 @@
-
 import curses
 import sys
 import time

--- a/alertaclient/utils.py
+++ b/alertaclient/utils.py
@@ -1,6 +1,8 @@
-
 import datetime
 import json
+import os
+import platform
+import sys
 
 import click
 import pytz
@@ -56,3 +58,8 @@ def action_progressbar(client, action, ids, label, text=None, timeout=None):
                 client.action(id, action=action, text=text or 'status changed using CLI', timeout=timeout)
             except Exception:
                 skipped += 1
+
+
+def origin():
+    prog = os.path.basename(sys.argv[0])
+    return '{}/{}'.format(prog, platform.uname()[1])

--- a/tests/test_alerts.py
+++ b/tests/test_alerts.py
@@ -1,4 +1,3 @@
-
 import unittest
 
 import requests_mock

--- a/tests/test_blackouts.py
+++ b/tests/test_blackouts.py
@@ -1,4 +1,3 @@
-
 import unittest
 
 import requests_mock

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -4,6 +4,7 @@ import requests_mock
 from click.testing import CliRunner
 
 from alertaclient.api import Client
+from alertaclient.commands.cmd_send import cli as send
 from alertaclient.commands.cmd_whoami import cli as whoami
 from alertaclient.config import Config
 
@@ -18,6 +19,104 @@ class CommandsTestCase(unittest.TestCase):
         self.obj['client'] = self.client
 
         self.runner = CliRunner()
+
+    @requests_mock.mock()
+    def test_send_cmd(self, m):
+
+        send_response = """
+        {
+          "alert": {
+            "attributes": {},
+            "correlate": [],
+            "createTime": "2020-01-17T23:23:31.441Z",
+            "customer": null,
+            "duplicateCount": 10,
+            "environment": "Development",
+            "event": "node_down",
+            "group": "Misc",
+            "history": [
+              {
+                "event": "node_down",
+                "href": "https://alerta-api.herokuapp.com/alert/cca2053f-806d-478c-abb3-bbec6fddbb49",
+                "id": "cca2053f-806d-478c-abb3-bbec6fddbb49",
+                "severity": "major",
+                "status": "open",
+                "text": "new alert",
+                "type": "new",
+                "updateTime": "2020-01-17T23:23:31.441Z",
+                "user": "admin@alerta.io",
+                "value": null
+              },
+              {
+                "event": "node_down",
+                "href": "https://alerta-api.herokuapp.com/alert/cca2053f-806d-478c-abb3-bbec6fddbb49",
+                "id": "cca2053f-806d-478c-abb3-bbec6fddbb49",
+                "severity": "major",
+                "status": "shelved",
+                "text": "",
+                "type": "shelve",
+                "updateTime": "2020-01-18T02:31:56.863Z",
+                "user": null,
+                "value": null
+              },
+              {
+                "event": "node_down",
+                "href": "https://alerta-api.herokuapp.com/alert/cca2053f-806d-478c-abb3-bbec6fddbb49",
+                "id": "cca2053f-806d-478c-abb3-bbec6fddbb49",
+                "severity": "major",
+                "status": "open",
+                "text": "",
+                "type": "unshelve",
+                "updateTime": "2020-01-18T02:33:41.863Z",
+                "user": null,
+                "value": null
+              },
+              {
+                "event": "node_down",
+                "href": "https://alerta-api.herokuapp.com/alert/cca2053f-806d-478c-abb3-bbec6fddbb49",
+                "id": "cca2053f-806d-478c-abb3-bbec6fddbb49",
+                "severity": "major",
+                "status": "ack",
+                "text": "",
+                "type": "ack",
+                "updateTime": "2020-01-18T02:33:49.536Z",
+                "user": null,
+                "value": null
+              }
+            ],
+            "href": "https://alerta-api.herokuapp.com/alert/cca2053f-806d-478c-abb3-bbec6fddbb49",
+            "id": "cca2053f-806d-478c-abb3-bbec6fddbb49",
+            "lastReceiveId": "c3d6a74a-e346-4293-a44c-f6b3465e8732",
+            "lastReceiveTime": "2020-01-18T12:58:24.100Z",
+            "origin": "gunicorn/47e463df-f3db-4786-93e6-1d4f029666b3",
+            "previousSeverity": "indeterminate",
+            "rawData": null,
+            "receiveTime": "2020-01-17T23:23:31.684Z",
+            "repeat": true,
+            "resource": "web01",
+            "service": [
+              "Web"
+            ],
+            "severity": "major",
+            "status": "ack",
+            "tags": [],
+            "text": "Web server web01 is down",
+            "timeout": 86400,
+            "trendIndication": "moreSevere",
+            "type": "exceptionAlert",
+            "updateTime": "2020-01-18T02:33:49.536Z",
+            "value": null
+          },
+          "id": "cca2053f-806d-478c-abb3-bbec6fddbb49",
+          "status": "ok"
+        }
+        """
+
+        m.post('/alert', text=send_response)
+        result = self.runner.invoke(send, ['-r', 'web01', '-e', 'node_down', '-E', 'Development', '-S', 'Web', '-s', 'major'], obj=self.obj)
+        print(result.runner.__dict__)
+        self.assertIn('foo', result.output)
+        self.assertEqual(result.exit_code, 0)
 
     @requests_mock.mock()
     def test_whoami_cmd(self, m):

--- a/tests/test_customers.py
+++ b/tests/test_customers.py
@@ -1,4 +1,3 @@
-
 import unittest
 
 import requests_mock

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -1,4 +1,3 @@
-
 import unittest
 
 import requests_mock

--- a/tests/test_heartbeats.py
+++ b/tests/test_heartbeats.py
@@ -1,4 +1,3 @@
-
 import unittest
 
 import requests_mock

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,4 +1,3 @@
-
 import unittest
 
 import requests_mock

--- a/tests/test_keys.py
+++ b/tests/test_keys.py
@@ -1,4 +1,3 @@
-
 import unittest
 
 import requests_mock

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -1,4 +1,3 @@
-
 import unittest
 
 import requests_mock

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1,4 +1,3 @@
-
 import unittest
 
 import requests_mock

--- a/tests/test_remoteconfig.py
+++ b/tests/test_remoteconfig.py
@@ -1,4 +1,3 @@
-
 import unittest
 
 import requests

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,4 +1,3 @@
-
 import unittest
 
 import requests_mock


### PR DESCRIPTION
```
% alerta heartbeat -h
Usage: alerta heartbeat [OPTIONS]

  Send or delete a heartbeat.

  Note: The "environment", "severity", "service" and "group" values are only
  used when heartbeat alerts are generated from slow or stale heartbeats.

Options:
  -O, --origin ORIGIN            Origin of heartbeat.
  -E, --environment ENVIRONMENT  Environment eg. Production, Development
  -s, --severity SEVERITY        Severity eg. critical, major, minor, warning
  -S, --service SERVICE          List of affected services eg. app name, Web,
                                 Network, Storage, Database, Security
  -g, --group GROUP              Group event by type eg. OS, Performance
  -T, --tag TAG                  List of tags eg. London, os:linux, AWS/EC2
  --timeout SECONDS              Seconds before heartbeat is stale
  --customer STRING              Customer
  -D, --delete ID                Delete hearbeat using ID
  -h, --help                     Show this message and exit.
```

See alerta/alerta#1110 and alerta/alerta#1128