### PR TITLE
fixes basic auth with ldap provider

### DIFF
--- a/alertaclient/commands/cmd_login.py
+++ b/alertaclient/commands/cmd_login.py
@@ -31,7 +31,7 @@ def cli(obj, username):
             token = google.login(client, username, client_id)['token']
         elif provider == 'openid':
             token = oidc.login(client, obj['oidc_auth_url'], client_id)['token']
-        elif provider == 'basic':
+        elif provider == 'basic' or provider == 'ldap':
             if not username:
                 username = click.prompt('Email')
             password = click.prompt('Password', hide_input=True)


### PR DESCRIPTION
### Current situation
Using ldap as auth provider does not work with the login command:
```
alerta login
```
ends in error: `ERROR: unknown provider ldap`

### Should
Successful authentication.

This minimal pr fixes basic auth using the ldap auth provider.