### PR TITLE
Fix heartbeat alert severity logic

### DIFF
--- a/alertaclient/commands/cmd_heartbeat.py
+++ b/alertaclient/commands/cmd_heartbeat.py
@@ -30,6 +30,12 @@ def cli(obj, origin, environment, severity, service, group, tags, timeout, custo
         if any(t.startswith('environment') or t.startswith('group') for t in tags):
             click.secho('WARNING: Do not use tags for "environment" or "group". See help.', err=True)
 
+        if severity in ['normal', 'ok', 'cleared']:
+            raise click.UsageError('Must be a non-normal severity.')
+
+        if severity not in obj['alarm_model']['severity'].keys():
+            raise click.UsageError('Must be a valid severity.')
+
         attributes = dict()
         if environment:
             attributes['environment'] = environment

--- a/alertaclient/config.py
+++ b/alertaclient/config.py
@@ -25,12 +25,14 @@ default_config = {
 
 class Config:
 
-    def __init__(self, config_file):
+    def __init__(self, config_file, config_override=None):
         self.options = default_config
         self.parser = configparser.RawConfigParser(defaults=self.options)
 
         self.options['config_file'] = config_file or os.environ.get('ALERTA_CONF_FILE') or self.options['config_file']
         self.parser.read(os.path.expanduser(self.options['config_file']))
+
+        self.options.update(config_override or {})
 
     def get_config_for_profle(self, profile=None):
         want_profile = profile or os.environ.get('ALERTA_DEFAULT_PROFILE') or self.parser.defaults().get('profile')
@@ -62,8 +64,5 @@ class Config:
             raise ClientException('Failed to get config from {}. Reason: {}'.format(config_url, e))
         except json.decoder.JSONDecodeError:
             raise ClientException('Failed to get config from {}: Reason: not a JSON object'.format(config_url))
-
-        if not self.options['client_id']:
-            del self.options['client_id']
 
         self.options = {**remote_config, **self.options}

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -16,7 +16,29 @@ class CommandsTestCase(unittest.TestCase):
     def setUp(self):
         self.client = Client()
 
-        config = Config(config_file=None)
+        alarm_model = {
+            'name': 'Alerta 8.0.1',
+            'severity': {
+                'security': 0,
+                'critical': 1,
+                'major': 2,
+                'minor': 3,
+                'warning': 4,
+                'indeterminate': 5,
+                'informational': 6,
+                'normal': 7,
+                'ok': 7,
+                'cleared': 7,
+                'debug': 8,
+                'trace': 9,
+                'unknown': 10
+            },
+            'defaults': {
+                'normal_severity': 'normal'
+            }
+        }
+
+        config = Config(config_file=None, config_override={'alarm_model': alarm_model})
         self.obj = config.options
         self.obj['client'] = self.client
 
@@ -24,11 +46,6 @@ class CommandsTestCase(unittest.TestCase):
 
     @requests_mock.mock()
     def test_heartbeat_cmd(self, m):
-
-        config_response = """
-        {}
-        """
-        m.get('/config', text=config_response)
 
         heartbeat_response = """
         {
@@ -67,18 +84,13 @@ class CommandsTestCase(unittest.TestCase):
     @requests_mock.mock()
     def test_heartbeats_cmd(self, m):
 
-        config_response = """
-        {}
-        """
-        m.get('/config', text=config_response)
-
         heartbeats_response = """
         {
           "heartbeats": [
             {
               "attributes": {
                 "environment": "Infrastructure",
-                "severity": "Major",
+                "severity": "major",
                 "service": ["Internal"],
                 "group": "Heartbeats",
                 "region": "EU"
@@ -123,7 +135,7 @@ class CommandsTestCase(unittest.TestCase):
                 "event": "HeartbeatSlow",
                 "href": "http://api.local.alerta.io:8080/alert/6cfbc30f-c2d6-4edf-b672-841070995206",
                 "id": "6cfbc30f-c2d6-4edf-b672-841070995206",
-                "severity": "High",
+                "severity": "warning",
                 "status": "open",
                 "text": "new alert",
                 "type": "new",
@@ -137,7 +149,7 @@ class CommandsTestCase(unittest.TestCase):
             "lastReceiveId": "6cfbc30f-c2d6-4edf-b672-841070995206",
             "lastReceiveTime": "2020-03-10T21:55:07.916Z",
             "origin": "alerta/macbook.lan",
-            "previousSeverity": "Not classified",
+            "previousSeverity": "indeterminate",
             "rawData": null,
             "receiveTime": "2020-03-10T21:55:07.916Z",
             "repeat": false,
@@ -145,7 +157,7 @@ class CommandsTestCase(unittest.TestCase):
             "service": [
               "Internal"
             ],
-            "severity": "Major",
+            "severity": "warning",
             "status": "open",
             "tags": [],
             "text": "Heartbeat took more than 2ms to be processed",
@@ -169,7 +181,7 @@ class CommandsTestCase(unittest.TestCase):
         history = m.request_history
         data = history[1].json()
         self.assertEqual(data['environment'], 'Infrastructure')
-        self.assertEqual(data['severity'], 'Major')
+        self.assertEqual(data['severity'], 'major')
         self.assertEqual(data['service'], ['Internal'])
         self.assertEqual(data['group'], 'Heartbeats')
         self.assertEqual(data['attributes'], {'region': 'EU'})

--- a/tests/unit/test_remoteconfig.py
+++ b/tests/unit/test_remoteconfig.py
@@ -17,7 +17,7 @@ class RemoteConfigTestCase(unittest.TestCase):
           {
             "actions": [],
             "alarm_model": {
-              "name": "Alerta 6.7.5"
+              "name": "Alerta 8.0.1"
             },
             "audio": {
               "new": null
@@ -90,7 +90,7 @@ class RemoteConfigTestCase(unittest.TestCase):
         """Tests successful remote config fetch"""
         m.get('/api/config', text=self.remote_json_config, status_code=200)
         self.config.get_remote_config('http://localhost:8080/api')
-        self.assertEqual(self.config.options['alarm_model']['name'], 'Alerta 6.7.5')
+        self.assertEqual(self.config.options['alarm_model']['name'], 'Alerta 8.0.1')
 
     @requests_mock.mock()
     def test_config_timeout(self, m):


### PR DESCRIPTION
Ensure custom severity level used for "heartbeats" and  "heartbeat alerts" is a valid non-normal severity level. And that the severity level used for HeartbeatOK is the default normal severity.

Related to alerta/alerta#1251