### PR TITLE
Add support for client-side certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,18 +31,20 @@ Configuration
 Options can be set in a configuration file, as environment variables or on the command line.
 Profiles can be used to easily switch between different configuration settings.
 
-| Option     | Config File | Environment Variable       | Optional Argument               | Default                   |
-|------------|-------------|----------------------------|---------------------------------|---------------------------|
-| file       | n/a         | ``ALERTA_CONF_FILE``       | n/a                             | ``~/.alerta.conf``        |
-| profile    | profile     | ``ALERTA_DEFAULT_PROFILE`` | ``--profile PROFILE``           | None                      |
-| endpoint   | endpoint    | ``ALERTA_ENDPOINT``        | ``--endpoint-url URL``          | ``http://localhost:8080`` |
-| key        | key         | ``ALERTA_API_KEY``         | n/a                             | None                      |
-| timezone   | timezone    | n/a                        | n/a                             | Europe/London             |
-| SSL verify | sslverify   | ``REQUESTS_CA_BUNDLE``     | n/a                             | verify SSL certificates   |
-| timeout    | timeout     | n/a                        | n/a                             | 5s TCP connection timeout |
-| output     | output      | n/a                        | ``--output-format OUTPUT``      | simple                    |
-| color      | color       | ``CLICOLOR``               | ``--color``, ``--no-color``     | color on                  |
-| debug      | debug       | ``DEBUG``                  | ``--debug``                     | no debug                  |
+| Option            | Config File | Environment Variable       | Optional Argument               | Default                   |
+|-------------------|-------------|----------------------------|---------------------------------|---------------------------|
+| file              | n/a         | ``ALERTA_CONF_FILE``       | n/a                             | ``~/.alerta.conf``        |
+| profile           | profile     | ``ALERTA_DEFAULT_PROFILE`` | ``--profile PROFILE``           | None                      |
+| endpoint          | endpoint    | ``ALERTA_ENDPOINT``        | ``--endpoint-url URL``          | ``http://localhost:8080`` |
+| key               | key         | ``ALERTA_API_KEY``         | n/a                             | None                      |
+| timezone          | timezone    | n/a                        | n/a                             | Europe/London             |
+| SSL verify        | sslverify   | ``REQUESTS_CA_BUNDLE``     | n/a                             | verify SSL certificates   |
+| SSL client cert   | sslcert     | n/a                        | n/a                             | None                      |
+| SSL client key    | sslkey      | n/a                        | n/a                             | None                      |
+| timeout           | timeout     | n/a                        | n/a                             | 5s TCP connection timeout |
+| output            | output      | n/a                        | ``--output-format OUTPUT``      | simple                    |
+| color             | color       | ``CLICOLOR``               | ``--color``, ``--no-color``     | color on                  |
+| debug             | debug       | ``DEBUG``                  | ``--debug``                     | no debug                  |
 
 Example
 -------

--- a/alertaclient/api.py
+++ b/alertaclient/api.py
@@ -32,14 +32,16 @@ class Client:
 
     DEFAULT_ENDPOINT = 'http://localhost:8080'
 
-    def __init__(self, endpoint=None, key=None, secret=None, token=None, username=None, password=None, timeout=5.0, ssl_verify=True, headers=None, debug=False):
+    def __init__(self, endpoint=None, key=None, secret=None, token=None, username=None, password=None, timeout=5.0, ssl_verify=True,
+                 ssl_cert=None, ssl_key=None, headers=None, debug=False):
         self.endpoint = endpoint or os.environ.get('ALERTA_ENDPOINT', self.DEFAULT_ENDPOINT)
 
         if debug:
             HTTPConnection.debuglevel = 1
 
         key = key or os.environ.get('ALERTA_API_KEY', '')
-        self.http = HTTPClient(self.endpoint, key, secret, token, username, password, timeout, ssl_verify, headers, debug)
+        self.http = HTTPClient(self.endpoint, key, secret, token, username, password,
+                               timeout, ssl_verify, ssl_cert, ssl_key, headers, debug)
 
     # Alerts
     def send_alert(self, resource, event, **kwargs):
@@ -513,7 +515,21 @@ class HTTPClient:
     DEFAULT_PAGE_NUMBER = 1
     DEFAULT_PAGE_SIZE = 50
 
-    def __init__(self, endpoint, key=None, secret=None, token=None, username=None, password=None, timeout=30.0, ssl_verify=True, headers=None, debug=False):
+    def __init__(
+        self,
+        endpoint,
+        key=None,
+        secret=None,
+        token=None,
+        username=None,
+        password=None,
+        timeout=30.0,
+        ssl_verify=True,
+        ssl_cert=None,
+        ssl_key=None,
+        headers=None,
+        debug=False,
+    ):
         self.endpoint = endpoint
         self.auth = None
 
@@ -529,6 +545,9 @@ class HTTPClient:
         self.timeout = timeout
         self.session = requests.Session()
         self.session.verify = ssl_verify  # or use REQUESTS_CA_BUNDLE env var
+
+        if ssl_cert:
+            self.session.cert = (ssl_cert, ssl_key)
 
         self.headers = headers or dict()
         merge(self.headers, self.default_headers())

--- a/alertaclient/cli.py
+++ b/alertaclient/cli.py
@@ -68,5 +68,7 @@ def cli(ctx, config_file, profile, endpoint_url, output, color, debug):
         password=config.options.get('password', None),
         timeout=float(config.options['timeout']),
         ssl_verify=config.options['sslverify'],
+        ssl_cert=config.options.get('sslcert', None),
+        ssl_key=config.options.get('sslkey', None),
         debug=debug or os.environ.get('DEBUG', None) or config.options['debug']
     )

--- a/alertaclient/config.py
+++ b/alertaclient/config.py
@@ -17,6 +17,8 @@ default_config = {
     'timezone': 'Europe/London',
     'timeout': 5.0,
     'sslverify': True,
+    'sslcert': None,
+    'sslkey': None,
     'output': 'simple',
     'color': True,
     'debug': False
@@ -57,7 +59,7 @@ class Config:
     def get_remote_config(self, endpoint=None):
         config_url = '{}/config'.format(endpoint or self.options['endpoint'])
         try:
-            r = requests.get(config_url, verify=self.options['sslverify'])
+            r = requests.get(config_url, verify=self.options['sslverify'], cert=(self.options['sslcert'], self.options['sslkey']))
             r.raise_for_status()
             remote_config = r.json()
         except requests.RequestException as e:


### PR DESCRIPTION
This change allows specifying client certificates for SSL authentication.
